### PR TITLE
Option to map wiki users to git authors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Usage
     like Waliki, Gollum or similar.
 
     Usage:
-      moin2git.py migrate <data_dir> <git_repo> [--convert-to-rst]
+      moin2git.py migrate <data_dir> <git_repo> [--convert-to-rst] [--users-file <users_file>]
       moin2git.py users <data_dir>
       moin2git.py attachments <data_dir> <dest_dir>
 
@@ -50,6 +50,7 @@ Usage
 
     Options:
         --convert-to-rst    After migrate, convert to reStructuredText
+        --users-file        Use users_file to map wiki user to git commit author
 
 Workarounds
 -----------
@@ -209,6 +210,14 @@ get a file ``AlejandroJCura``:
 
 We should also get a file ``AlejandroJCura/ClassDecó`` [2]_ where, in this case, ``AlejandroJCura/`` is a directory.
 
+Commit authors
+--------------
+
+The option --users-file acepts a file that will be used to map wiki users
+to git commit authors.
+
+The output of the command ``moin2git.py users <data_dir>`` can be used
+as input. For each users the required fields are ``name`` and ``email``.
 
 
 .. [1] http://python.org.ar/AlejandroJCura/ClassDec%C3%B3

--- a/moin2git.py
+++ b/moin2git.py
@@ -49,7 +49,10 @@ def parse_users(data_dir=None):
     users = {}
     users_dir = os.path.join(data_dir, 'user')
     for autor in os.listdir(users_dir):
-        data = open(os.path.join(users_dir, autor)).read()
+        try:
+            data = open(os.path.join(users_dir, autor)).read()
+        except IOError:
+            continue
 
         users[autor] = dict(re.findall(r'^([a-z_]+)=(.*)$', data, flags=re.MULTILINE))
     return users

--- a/moin2git.py
+++ b/moin2git.py
@@ -7,7 +7,7 @@ A tool to migrate the content of a MoinMoin wiki to a Git based system
 like Waliki, Gollum or similar.
 
 Usage:
-  moin2git.py migrate <data_dir> <git_repo> [--convert-to-rst]
+  moin2git.py migrate <data_dir> <git_repo> [--convert-to-rst] [--users-file <users_file>]
   moin2git.py users <data_dir>
   moin2git.py attachments <data_dir> <dest_dir>
 
@@ -18,6 +18,7 @@ Arguments:
 
 Options:
     --convert-to-rst    After migrate, convert to reStructuredText
+    --users-file        Use users_file to map wiki user to git commit author
 """
 from sh import git, python, ErrorReturnCode_1
 import docopt
@@ -114,7 +115,10 @@ def get_versions(page, users=None, data_dir=None, convert=False):
 
 
 def migrate_to_git():
-    users = parse_users()
+    if arguments['--users-file']:
+        users = json.loads(open(arguments['<users_file>']).read())
+    else:
+        users = parse_users()
     git_repo = arguments['<git_repo>']
 
     if not os.path.exists(git_repo):


### PR DESCRIPTION
Add an option `[--users-file <users_file>]` to provide a file to map wiki users to git authors. 

The format of the input file is the same that generated with users command. We can use `moin2git.py users wiki_data > users.txt` to generate an initial list. Edit users.txt replacing the required fields **name** and **email**.

For example this is a valid input

```
{
  "1286719782.91.29531": {
    "email": "ismaelbej@gmail.com", 
    "name": "Ismael Bejarano" 
  },
}
```

Now it can be used like this `moin2git.py migrate wiki_data git_repo --users-file users.txt`.
